### PR TITLE
Support DATASET values that contain lists of dicts

### DIFF
--- a/specter/spec.py
+++ b/specter/spec.py
@@ -461,7 +461,7 @@ def convert_to_hashable(obj):
         hashed = tuple([(k, convert_to_hashable(v))
                        for k, v in six.iteritems(obj)])
     elif isinstance(obj, list):
-        hashed = tuple(obj)
+        hashed = tuple(convert_to_hashable(item) for item in obj)
     return hashed
 
 

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -5,7 +5,8 @@ except ImportError:
 from time import sleep
 
 from specter.spec import (TimedObject, CaseWrapper, Spec, Describe,
-                          copy_function, get_function_kwargs)
+                          copy_function, get_function_kwargs,
+                          convert_to_hashable)
 
 
 class TestTimedObject(TestCase):
@@ -128,3 +129,21 @@ class TestSpecHelpers(TestCase):
         kwargs = get_function_kwargs(test_func, args)
         self.assertEqual(kwargs.get('arg'), 'temp')
         self.assertIsNone(kwargs.get('argv'))
+
+
+class TestConvertToHashable(TestCase):
+
+    def test_dict(self):
+        hash(convert_to_hashable({}))
+
+    def test_list(self):
+        hash(convert_to_hashable([]))
+
+    def test_list_of_dicts(self):
+        hash(convert_to_hashable([{}, {}, {}]))
+
+    def test_dict_with_list_values(self):
+        hash(convert_to_hashable({'a': [], 'b': []}))
+
+    def test_dict_with_list_of_dict_values(self):
+        hash(convert_to_hashable({'a': [{}, {}], 'b': [{}, {}]}))


### PR DESCRIPTION
I get an error `TypeError: unhashable type: 'dict'` running specter when a `DATASET` has a list of dicts, as in the following:

    from specter import DataSpec


    class Thing(DataSpec):
        DATASET = {
            'wumbo': {
                'data': [
                    {},
                    {},
                ]
            },
        }

        def can_set_to(self, data):
            pass

And the exact exception:

     $ specter

              ___
            _/ @@\
        ~- ( \  O/__     Specter
        ~-  \    \__)   ~~~~~~~~~~
        ~-  /     \     Keeping the Bogeyman away from your code!
        ~- /      _\
           ~~~~~~~~~
        
    Traceback (most recent call last):
      File "/Users/paul7502/.virtualenvs/specter/bin/specter", line 9, in <module>
        load_entry_point('Specter==0.2.1', 'console_scripts', 'specter')()
      File "/Users/paul7502/Specter/specter/runner.py", line 188, in activate
        runner.run(args)
      File "/Users/paul7502/Specter/specter/runner.py", line 158, in run
        suite = suite_type()
      File "/Users/paul7502/Specter/specter/spec.py", line 436, in __init__
        if key_args in self.dups:
    TypeError: unhashable type: 'dict'

This fixes the `convert_to_hashable` function to descend into lists and convert all list items to hashables and adds tests for that function.