### PR TITLE
Support showing exceptions from old style classes

### DIFF
--- a/specter/util.py
+++ b/specter/util.py
@@ -4,6 +4,11 @@ import itertools
 import sys
 import six
 
+try:
+    import __builtin__
+except ImportError:
+    import builtins as __builtin__
+
 CAPTURED_TRACEBACKS = []
 
 
@@ -43,7 +48,12 @@ def get_expect_param_strs(src_line):
 def get_source_from_frame(frame):
     self = frame.f_locals.get('self', None)
     cls = frame.f_locals.get('cls', None)
+
+    # for old style classes, getmodule(type(self)) returns __builtin__, and
+    # inspect.getfile(__builtin__) throws an exception
     insp_obj = inspect.getmodule(type(self) if self else cls) or frame.f_code
+    if insp_obj == __builtin__:
+        insp_obj = frame.f_code
 
     line_num_modifier = 0
     if inspect.iscode(insp_obj):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -55,3 +55,13 @@ class TestSpecterUtil(TestCase):
 
         func, meta = util.extract_metadata(sample_func)
         self.assertEqual(meta.get('type'), 'testing')
+
+    def test_get_real_last_traceback_w_exception_in_old_style_class(self):
+        class OldStyleClass:
+            def throw(self):
+                raise Exception('exception in OldStyleClass')
+
+        try:
+            OldStyleClass().throw()
+        except Exception as e:
+            util.get_real_last_traceback(e)


### PR DESCRIPTION
This fixes an exception, `TypeError: <module '__builtin__' (built-in)> is a built-in module`, that is thrown when specter tries to print a stack trace for an exception raised from a method on an old-style class.

What happens is: specter calls `inspect.getmodule(type(self))`. When `self` is an instance of an old-style class,`type(self) == <type 'instance'>`, and then `getmodule(type(self)) == <module '__builtin__' (built-in)>`. After that, it calls `inspect.getfile(__builtin__)` which [raises a `TypeError` on builtin modules/classes/functions](https://docs.python.org/2/library/inspect.html#inspect.getfile).

This doesn't affect Python 3, where all classes are new-style classes, and specter didn't have any problem with exceptions from static/class methods on old-style classes.

To reproduce:

    $ cat spec/thing.py
    from specter import Spec


    class OldStyle:

        def throw(self):
            raise Exception("an exception from an old style class (self.throw())")


    class Wumbo(Spec):

        def f(self):
            OldStyle().throw()
    $ specter

              ___
            _/ @@\
        ~- ( \  O/__     Specter
        ~-  \    \__)   ~~~~~~~~~~
        ~-  /     \     Keeping the Bogeyman away from your code!
        ~- /      _\
           ~~~~~~~~~

    Wumbo
    Traceback (most recent call last):
      File "/Users/paul7502/.virtualenvs/specter/bin/specter", line 9, in <module>
        load_entry_point('Specter==0.2.1', 'console_scripts', 'specter')()
      File "/Users/paul7502/Specter/specter/runner.py", line 188, in activate
        runner.run(args)
      File "/Users/paul7502/Specter/specter/runner.py", line 162, in run
        parallel_manager=self.parallel_manager)
      File "/Users/paul7502/Specter/specter/spec.py", line 376, in execute
        self.standard_execution(select_metadata)
      File "/Users/paul7502/Specter/specter/spec.py", line 350, in standard_execution
        case.execute(context=self._state)
      File "/Users/paul7502/Specter/specter/spec.py", line 101, in execute
        self.error = get_real_last_traceback(e)
      File "/Users/paul7502/Specter/specter/util.py", line 99, in get_real_last_traceback
        lines, path, line_num = get_source_from_frame(traceback.tb_frame)
      File "/Users/paul7502/Specter/specter/util.py", line 52, in get_source_from_frame
        module_path = inspect.getfile(insp_obj)
      File "/Users/paul7502/.pyenv/versions/2.7.6/lib/python2.7/inspect.py", line 403, in getfile
        raise TypeError('{!r} is a built-in module'.format(object))
    TypeError: <module '__builtin__' (built-in)> is a built-in module