### PR TITLE
A fix for an error on grabbing source lines across modules

### DIFF
--- a/specter/util.py
+++ b/specter/util.py
@@ -21,23 +21,12 @@ def convert_camelcase(input_str):
 
 
 def get_called_src_line(steps=2, use_child_attr=None):
-    src_line, last_frame = None, inspect.currentframe()
-
-    for i in range(steps):
-        last_frame = last_frame.f_back
-
-    self = module = last_frame.f_locals['self']
-    # Use an attr instead of self
-    if use_child_attr:
-        module = getattr(self, use_child_attr)
-
-    try:
-        last_module = inspect.getmodule(type(module))
-        line = last_frame.f_lineno - 1
-        src_line = inspect.getsourcelines(last_module)[0][line]
-    except:
-        pass
-    return src_line
+    stack = inspect.stack()
+    if 0 <= steps < len(stack):
+        stack_entry = stack[steps]
+        frame, filename, lineno, function_name, lines, _ = stack_entry
+        return "".join(lines)
+    return ""
 
 
 def get_expect_param_strs(src_line):

--- a/tests/sample_classes.py
+++ b/tests/sample_classes.py
@@ -1,0 +1,13 @@
+from specter import util
+
+
+class BaseForGetCalledSrcLine(object):
+
+    def first(self, steps):
+        return self.second(steps)
+
+
+class SubclassForGetCalledSrcLine(BaseForGetCalledSrcLine):
+
+    def second(self, steps):
+        return util.get_called_src_line(steps=steps)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,12 +2,32 @@ from unittest import TestCase
 
 from specter import util, spec, metadata, skip
 
+import sample_classes
+
 
 class TestSpecterUtil(TestCase):
 
     def test_get_called_src_line_error(self):
         handled = util.get_called_src_line()
         self.assertIsNone(handled)
+
+    def test_get_called_src_line(self):
+        x = sample_classes.SubclassForGetCalledSrcLine()
+        self.assertEqual(x.first(steps=1).strip(),
+                         "return util.get_called_src_line(steps=steps)")
+        self.assertEqual(x.first(steps=2).strip(),
+                         "return self.second(steps)")
+
+    def test_get_called_src_line_across_modules(self):
+        # the base and sub classes need to be in separate modules
+        class SubClass(sample_classes.BaseForGetCalledSrcLine):
+            def second(self, steps):
+                return util.get_called_src_line(steps=steps)
+        x = SubClass()
+        self.assertEqual(x.first(steps=1).strip(),
+                         "return util.get_called_src_line(steps=steps)")
+        self.assertEqual(x.first(steps=2).strip(),
+                         "return self.second(steps)")
 
     def test_convert_camelcase_error(self):
         result = util.convert_camelcase(None)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,8 +8,11 @@ import sample_classes
 class TestSpecterUtil(TestCase):
 
     def test_get_called_src_line_error(self):
-        handled = util.get_called_src_line()
-        self.assertIsNone(handled)
+        handled = util.get_called_src_line(steps=-1)
+        self.assertEqual(handled, '')
+
+        handled = util.get_called_src_line(steps=10000)
+        self.assertEqual(handled, '')
 
     def test_get_called_src_line(self):
         x = sample_classes.SubclassForGetCalledSrcLine()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from specter import util, spec, metadata, skip
 
-import sample_classes
+import tests.sample_classes as sample_classes
 
 
 class TestSpecterUtil(TestCase):


### PR DESCRIPTION
This should fix an issue where an exception is thrown when a test calls out to another module/function that uses `expect()`. An example: https://gist.github.com/pglass/02978516cbf4e2ec41e2

The actual issue was that `get_called_src_line` wasn't fetching the line from the correct module. If there was an `expect()` in another module, would fetch the line from the module containing test case being executed, I think, rather than the module where the except existed (because it was looking for the module based off of the state object). Sometimes the module it found didn't have enough lines, which produced an index out of bounds that turned into a different exception.