### PR TITLE
Adds support for hooks.

### DIFF
--- a/specter/spec.py
+++ b/specter/spec.py
@@ -153,6 +153,9 @@ class CaseWrapper(TimedObject):
 class Describe(EventDispatcher):
     __FIXTURE__ = False
 
+    #: List of methods to be called after every test
+    hooks = ()
+
     def __init__(self, parent=None):
         super(Describe, self).__init__()
         self.id = str(uuid.uuid4())
@@ -294,6 +297,11 @@ class Describe(EventDispatcher):
         }
         return converted_dict
 
+    def _run_hooks(self):
+        """Calls any registered hooks providing the current state."""
+        for hook in self.hooks:
+            getattr(self, hook)(self._state)
+
     def __create_state_obj__(self):
         """ Generates the clean state object magic. Here be dragons! """
         stops = [Describe, Spec, DataDescribe, EventDispatcher]
@@ -349,6 +357,7 @@ class Describe(EventDispatcher):
             self._state.before_each()
             case.execute(context=self._state)
             self._state.after_each()
+            self._run_hooks()
             self._num_completed_cases += 1
 
             self.top_parent.dispatch(TestEvent(case))

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -110,6 +110,23 @@ class TestSpecDescribe(TestCase):
     def test_success_property(self):
         self.assertFalse(self.spec.success)
 
+    def test_execute_with_hooks(self):
+        hook1_calls = []
+        spec = ExampleSpec()
+        spec._hook1 = lambda s: hook1_calls.append(s)
+
+        spec.standard_execution()
+        self.assertEqual(len(hook1_calls), 0)
+        self.assertTrue(spec.complete)
+
+        spec = ExampleSpec()
+        spec._hook1 = lambda s: hook1_calls.append(s)
+        spec.hooks = ('_hook1',)
+        spec.standard_execution()
+
+        self.assertEqual(len(hook1_calls), 1)
+        self.assertTrue(spec.complete)
+
 
 class TestSpecHelpers(TestCase):
 


### PR DESCRIPTION
This allows registering calls independent from the setup/teardown.
Having this, tools like flexmock or other cleaning methods can be
enabled.

In our case we are using flexmock, and in order to cleanup its state, we need to register `flexmock_teardown()`.

While the framework provides integration with some of the most popular testing tools, specter lacks out of the box support:
https://github.com/has207/flexmock/blob/master/flexmock.py#L1202-L1359

@jmvrbanac let me know what do you think about this?
Thanks.