### PR TITLE
Add be_almost_equal assertion.

### DIFF
--- a/docs/writing_tests/index.rst
+++ b/docs/writing_tests/index.rst
@@ -163,7 +163,7 @@ Available Comparisons
     * equal(expected_object)
     * be_greater_than(expected_object)
     * be_less_than(expected_object)
-    * be_almost_equal(expected_object, places)
+    * be_almost_equal(expected_number, places)
     * be_none()
     * be_true()
     * be_false()

--- a/docs/writing_tests/index.rst
+++ b/docs/writing_tests/index.rst
@@ -163,6 +163,7 @@ Available Comparisons
     * equal(expected_object)
     * be_greater_than(expected_object)
     * be_less_than(expected_object)
+    * be_almost_equal(expected_object, places)
     * be_none()
     * be_true()
     * be_false()

--- a/specter/expect.py
+++ b/specter/expect.py
@@ -69,6 +69,11 @@ class ExpectAssert(object):
         self._compare(action_name=_('equal'), expected=expected,
                       condition=self.target == expected)
 
+    def be_almost_equal(self, expected, places=None):
+        places = places or 7
+        self._compare(action_name=_('be almost equal within {} places'), expected=expected,
+                      condition=round(abs(self.target - expected), places) == 0)
+
     def be_greater_than(self, expected):
         self._compare(action_name=_('be greater than'), expected=expected,
                       condition=self.target > expected)

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -42,6 +42,24 @@ class TestExpectAssertion(TestCase):
         expect.not_to.equal('nope')
         self.assertTrue(expect.success)
 
+    def test_expect_almost_equal(self):
+        target = 0.010000001
+        expect = self._create_assert(target)
+        expect.to.be_almost_equal(0.01)
+        self.assertTrue(expect.success)
+
+    def test_expect_almost_equal_with_places(self):
+        target = 0.011
+        expect = self._create_assert(target)
+        expect.to.be_almost_equal(0.01, places=2)
+        self.assertTrue(expect.success)
+
+    def test_expect_not_to_almost_equal(self):
+        target = 0.01
+        expect = self._create_assert(target)
+        expect.not_to.be_almost_equal(0.02)
+        self.assertTrue(expect.success)
+
     def test_expect_greater_than(self):
         target = 100
         expect = self._create_assert(target)


### PR DESCRIPTION
Hey, @jmvrbanac, thanks for a great testing library!

I'm not sure this fits into the original Specter design, but in some places we actually compare floats and from time to time get failures like:
```
      ∟ it returns 201 with new drug list payload
        ✔ response.status_code to equal 201
        ✔ False to equal False
        ✔ 30 to equal 30
        ✘ 1.59 to equal 1.59
            Target: 1.59
            Expected: 1.59
```
or similar. 

What would you say about adding `be_almost_equal`?