### PR TITLE
Fix printing failed expects

### DIFF
--- a/specter/runner.py
+++ b/specter/runner.py
@@ -200,5 +200,6 @@ def activate():  # pragma: no cover
         if not suite.success:
             exit(1)
 
+
 if __name__ == "__main__":
     activate()

--- a/specter/util.py
+++ b/specter/util.py
@@ -33,14 +33,18 @@ class ExpectParams(object):
 
         # Walk the tree until we get the expression we need
         expect_exp = None
+        closest_exp = None
         for node in ast.walk(tree):
             if isinstance(node, ast.Expr):
-                if node.lineno > line:
+                if node.lineno == line:
+                    expect_exp = node
                     break
 
-                expect_exp = node
+                if (closest_exp is None or
+                    abs(node.lineno - line) < abs(closest_exp.lineno - line)):
+                    closest_exp = node
 
-        self.expect_exp = expect_exp
+        self.expect_exp = expect_exp or closest_exp
 
     @property
     def cmp_call(self):

--- a/specter/util.py
+++ b/specter/util.py
@@ -29,6 +29,9 @@ class ExpectParams(object):
     ]
 
     def __init__(self, line, module):
+        def distance(node):
+            return abs(node.lineno - line)
+
         tree = ast.parse(inspect.getsource(module))
 
         # Walk the tree until we get the expression we need
@@ -41,7 +44,7 @@ class ExpectParams(object):
                     break
 
                 if (closest_exp is None or
-                    abs(node.lineno - line) < abs(closest_exp.lineno - line)):
+                        distance(node) < distance(closest_exp)):
                     closest_exp = node
 
         self.expect_exp = expect_exp or closest_exp


### PR DESCRIPTION
### Issue

When instantiating an `ExpectParams` object, in some cases, the wrong node is assigned to `self.expect_exp`. 
This causes printing of wrong error messages when tests fail.

##### Example:
```python
def it_works(self):
    a = 0
    b = 1
    c = 2

    expect(a).to.equal(0)
    expect(b).to.equal(1)
    expect(c).to.equal(4)
``` 

can return the following output:
```
 ∟ it works
    ✔ a to equal 0
    ✔ a to equal 1
    ✘ a to equal 4
        a: 2
```

### Solution

* Try to find the node having the exact same line number as the expect
* Otherwise fallback to the closest node found