### PR TITLE
Sort test cases before execution to ensure stable order between multiple runs

### DIFF
--- a/specter/spec.py
+++ b/specter/spec.py
@@ -340,8 +340,8 @@ class Describe(EventDispatcher):
         return state_cls()
 
     def _sort_cases(self, cases):
-        sort_key = lambda (key, case): case.case_func.__name__
-        sorted_cases = sorted(cases.items(), key=sort_key)
+        sorted_cases = sorted(
+            cases.items(), key=lambda case: case[1].case_func.__name__)
         return collections.OrderedDict(sorted_cases)
 
     def parallel_execution(self, manager, select_metadata=None,

--- a/specter/spec.py
+++ b/specter/spec.py
@@ -1,4 +1,5 @@
 import copy
+import collections
 import inspect
 import itertools
 import sys
@@ -338,6 +339,11 @@ class Describe(EventDispatcher):
         state_cls = chain[-1:][0]
         return state_cls()
 
+    def _sort_cases(self, cases):
+        sort_key = lambda (key, case): case.case_func.__name__
+        sorted_cases = sorted(cases.items(), key=sort_key)
+        return collections.OrderedDict(sorted_cases)
+
     def parallel_execution(self, manager, select_metadata=None,
                            select_tests=None):
         self.top_parent.dispatch(DescribeEvent(DescribeEvent.START, self))
@@ -388,6 +394,10 @@ class Describe(EventDispatcher):
         # If it doesn't have tests or describes don't run it
         if len(self.cases) <= 0 and len(self.describes) <= 0:
             return
+
+        # Sort suite case funcs to ensure stable order of execution
+        self.cases = self._sort_cases(self.cases)
+
         if parallel_manager:
             self.parallel_execution(
                 parallel_manager,


### PR DESCRIPTION
### Issue
We test APIs a lot. Some of our test suits share fixtures set ups in order to save execution time, say, whenever one is testing a single controller. We use shared Fixture class, so that `before_all` and `after_all` are executed once and we try to ensure that separate tests in scope of a single suite do cleanup. 
Specter gather test cases into dictionaries, which makes order of execution in scope of suite unpredictable. Having some suits with dozen of tests, we sometimes observe strange failures related to the order of test runs. This sometimes visible only after we merge to master or even worse, reproduces itself randomly at times.

### Solution
Order test cases by `case_func` names before we dive into execution.