### PR TITLE
Removing duplicate dataset removal logic

### DIFF
--- a/docs/writing_tests/index.rst
+++ b/docs/writing_tests/index.rst
@@ -227,10 +227,6 @@ This dataset will produce a Spec with two tests: "sample_data_test" and "sample_
         ✘ "sample_text2" to equal "sample_text"
 
 
-.. note::
-
-    Specter will automatically remove duplicated tests within a dataset and will inform you about how many duplications were found.
-
 Metadata in Data-Driven
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 There are two different methods of adding metadata to your data-driven tests. The first method is to assign metadata to the entire set of data-driven tests.

--- a/specter/reporting/console.py
+++ b/specter/reporting/console.py
@@ -1,5 +1,5 @@
 from specter import _
-from specter.spec import TestEvent, DescribeEvent, DataDescribe
+from specter.spec import TestEvent, DescribeEvent
 from specter.reporting import AbstractConsoleReporter, AbstractSerialReporter
 from specter.reporting.utils import (
     TestStatus, print_expects, print_to_screen, get_color_from_status,
@@ -135,13 +135,6 @@ class ConsoleReporter(AbstractConsoleReporter, AbstractSerialReporter):
         # Output Docstrings if enabled
         if evt.payload.doc and self.output_docstrings:
             print_indent_msg(evt.payload.doc, level + 1)
-
-        # Warn of duplicates
-        if isinstance(evt.payload, DataDescribe) and evt.payload.dup_count:
-            color = ConsoleColors.YELLOW if self.use_color else None
-            print_indent_msg('Warning: Noticed {0} duplicate data '
-                             'set(s)'.format(evt.payload.dup_count),
-                             level + 1, color=color)
 
     def output(self, msg, indent, status=None):
         """ Alias for print_indent_msg with color determined by status."""

--- a/specter/spec.py
+++ b/specter/spec.py
@@ -447,9 +447,6 @@ class DataDescribe(Describe):
         super(DataDescribe, self).__init__(parent=parent)
         self.cases = {}
 
-        self.dup_count = 0
-        self.dups = set()
-
         # Generate new functions and monkey-patch
         for case_func in self.case_funcs:
             extracted_func, base_metadata = extract_metadata(case_func)
@@ -461,15 +458,6 @@ class DataDescribe(Describe):
                 if 'args' in data and 'meta' in data:
                     args = data.get('args', {})
                     meta.update(data.get('meta', {}))
-
-                # Skip duplicates
-                if args:
-                    key_args = convert_to_hashable(args)
-                    if key_args in self.dups:
-                        self.dup_count += 1
-                        continue
-                    else:
-                        self.dups.add(key_args)
 
                 # Extract name, args and duplicate function
                 func_name = '{0}_{1}'.format(extracted_func.__name__, name)

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -3,9 +3,10 @@ try:
 except ImportError:
     from unittest import TestCase
 from time import sleep
+import types
 
 from specter.spec import (TimedObject, CaseWrapper, Spec, Describe,
-                          copy_function, get_function_kwargs,
+                          DataSpec, copy_function, get_function_kwargs,
                           convert_to_hashable)
 
 
@@ -126,6 +127,37 @@ class TestSpecDescribe(TestCase):
 
         self.assertEqual(len(hook1_calls), 1)
         self.assertTrue(spec.complete)
+
+
+# Data class structure used for testing
+class ExampleDataSpec(DataSpec):
+    DATASET = {
+        'test': {'thing': 'trace', 'thing2': 'boom'},
+        'another': {'thing': 'trace', 'thing2': 'boom'},
+    }
+
+    def tracer(self, thing, thing2):
+        pass
+
+    def nope(self, thing, thing2):
+        pass
+
+
+class TestDataSpec(TestCase):
+    def setUp(self):
+        self.spec = ExampleDataSpec()
+
+    def test_functions(self):
+        funcs = [
+            getattr(self.spec, 'tracer_test'),
+            getattr(self.spec, 'tracer_another'),
+            getattr(self.spec, 'nope_test'),
+            getattr(self.spec, 'nope_another')
+        ]
+
+        self.assertTrue(all(funcs))
+        for func in funcs:
+            self.assertIsInstance(func, types.FunctionType)
 
 
 class TestSpecHelpers(TestCase):


### PR DESCRIPTION
This functionality, while nice, tends to result in duplicated
test code. Removing this functionality for the time being.
Perhaps we'll figure out a better way of doing this in the future.