### PR TITLE
Handle incoming CLI arguments better as it pertains to bools

### DIFF
--- a/specter/__main__.py
+++ b/specter/__main__.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 from specter.runner import SpecterRunner
+from specter.utils import translate_cli_argument
 
 
 def main(argv=None):
@@ -19,7 +20,7 @@ def main(argv=None):
 
     if arguments.select_metadata:
         select_metadata = {
-            key: value.strip('"\'')
+            key: translate_cli_argument(value.strip('"\''))
             for key, value in [
                 item.split('=')
                 for item in arguments.select_metadata

--- a/specter/utils.py
+++ b/specter/utils.py
@@ -9,6 +9,8 @@ from specter import logger
 log = logger.get(__name__)
 
 SOURCE_CACHE = {}
+TRUE_STRINGS = frozenset(['true', 'True'])
+FALSE_STRINGS = frozenset(['false', 'False'])
 
 
 def get_fullname(obj):
@@ -156,3 +158,15 @@ def find_by_metadata(metadata, cases):
                 selected_cases.append(case)
 
     return selected_cases
+
+
+def translate_cli_argument(argument):
+    converted = argument
+
+    if argument in TRUE_STRINGS:
+        converted = True
+
+    elif argument in FALSE_STRINGS:
+        converted = False
+
+    return converted


### PR DESCRIPTION
There was an issue where if a boolean value was used in the @metdata decorator, the comparison to select tests by their metadata would fail, because the CLI argument would come in as a string. This PR addresses that.