### PR TITLE
MAD-1513: Port XML test results reporter from old specter into the new async specter branch

### DIFF
--- a/specter/__init__.py
+++ b/specter/__init__.py
@@ -1,5 +1,2 @@
-from .spec import (
-    Spec, DataSpec, skip, skip_if, incomplete, metadata, fixture,
-    concurrency
-)
+from .spec import Spec, DataSpec, skip, skip_if, incomplete, metadata, fixture, concurrency  # NOQA
 from .expect import expect, require  # NOQA

--- a/specter/__main__.py
+++ b/specter/__main__.py
@@ -30,6 +30,7 @@ def main(argv=None):
     runner = SpecterRunner(
         reporting_options={
             'show_all_expects': arguments.show_all_expects,
+            'xunit_results': arguments.xunit_results,
         },
         concurrency=concurrency,
     )
@@ -95,5 +96,13 @@ def setup_argparse():
         dest='show_all_expects',
         action='store_true',
         help='Displays all expectations for test cases',
+    )
+
+    parser.add_argument(
+        '--xunit-results',
+        dest='xunit_results',
+        metavar='',
+        default=None,
+        help='Saves out xUnit compatible results to a specified file',
     )
     return parser

--- a/specter/reporting/core.py
+++ b/specter/reporting/core.py
@@ -1,6 +1,8 @@
 from specter import logger, utils
 from specter.spec import get_case_data
 
+log = logger.get(__name__)
+
 
 class ReportManager(object):
     def __init__(self, reporting_options=None):
@@ -145,8 +147,7 @@ class CaseFormatData(object):
     def successful(self):
         tracebacks = getattr(self._case, '__tracebacks__', [])
         return (
-            not tracebacks and
-            all(expect.success for expect in self.expects)
+            not tracebacks and all(expect.success for expect in self.expects)
         )
 
     @property

--- a/specter/reporting/core.py
+++ b/specter/reporting/core.py
@@ -101,6 +101,10 @@ class CaseFormatData(object):
         return self._case.__name__
 
     @property
+    def class_name(self):
+        return utils.pretty_class_name(str(self._spec.__class__))
+
+    @property
     def start(self):
         return get_case_data(self._case).start_time
 
@@ -167,6 +171,7 @@ class CaseFormatData(object):
         return {
             'name': self.name,
             'raw_name': self.raw_name,
+            'class_name': self.class_name,
             'start': self.start,
             'end': self.end,
             'success': self.successful,

--- a/specter/reporting/core.py
+++ b/specter/reporting/core.py
@@ -112,7 +112,7 @@ class CaseFormatData(object):
 
     @property
     def class_name(self):
-        return utils.pretty_class_name(str(self._spec.__class__))
+        return utils.pretty_class_name(self._spec)
 
     @property
     def start(self):

--- a/specter/reporting/core.py
+++ b/specter/reporting/core.py
@@ -72,12 +72,20 @@ class SpecFormatData(object):
         return self._spec.__doc__
 
     @property
+    def elapsed_time(self):
+        elapsed = 0
+        for case in self.cases:
+            elapsed += case.elapsed_time
+        return elapsed
+
+    @property
     def as_dict(self):
         return {
             'name': self.name,
             'module': self.module,
             'doc': self.doc,
             'successful': self.successful,
+            'elapsed_time': self.elapsed_time,
             'cases': [case.as_dict for case in self.cases],
             'specs': [spec.as_dict for spec in self.specs],
         }
@@ -111,6 +119,11 @@ class CaseFormatData(object):
     @property
     def end(self):
         return get_case_data(self._case).end_time
+
+    @property
+    def elapsed_time(self):
+        elapsed = self.end - self.start
+        return elapsed if elapsed >= 0 else 0
 
     @property
     def metadata(self):
@@ -174,6 +187,7 @@ class CaseFormatData(object):
             'class_name': self.class_name,
             'start': self.start,
             'end': self.end,
+            'elapsed_time': self.elapsed_time,
             'success': self.successful,
             'skipped': self.skipped,
             'skip_reason': self.skip_reason,

--- a/specter/reporting/pretty.py
+++ b/specter/reporting/pretty.py
@@ -172,7 +172,7 @@ class PrettyRenderer(object):
                         if str(expect.expected_name) != str(expect.expected):
                             print_indent(
                                 f'| {expect.expected_name}: {expect.expected}',
-                                level+3,
+                                level + 3,
                                 color=get_expect_color(expect)
                             )
 
@@ -184,7 +184,7 @@ class PrettyRenderer(object):
                 print_errors(data.errors, level, 'Traceback occurred running after_each')
 
         for child_spec in spec.specs:
-            self.render_spec(child_spec, level+1)
+            self.render_spec(child_spec, level + 1)
 
         if getattr(spec._spec.after_all, '__tracebacks__', None):
             data = CaseFormatData(spec._spec, spec._spec.after_all)
@@ -217,12 +217,12 @@ def print_errors(errors, level, msg=None):
     print_indent('')
     print_indent(
         msg or 'Traceback occurred during execution',
-        level+2,
+        level + 2,
         color=fail
     )
     print_indent(
         '-' * 40,
-        level+2,
+        level + 2,
         color=fail
     )
 
@@ -230,6 +230,6 @@ def print_errors(errors, level, msg=None):
         for line in error:
             print_indent(
                 line,
-                level+2,
+                level + 2,
                 color=fail
             )

--- a/specter/reporting/xunit.py
+++ b/specter/reporting/xunit.py
@@ -87,6 +87,9 @@ class XUnitTestSuite(object):
 class XUnitTestCase(object):
     def __init__(self, case):
         self.case = case
+        self.skipped_case = XUnitSkippedCase(self.case)
+        self.failure_case = XUnitFailureCase(self.case)
+        self.error_case = XUnitErrorCase(self.case)
 
     @property
     def name(self):
@@ -104,6 +107,53 @@ class XUnitTestCase(object):
         element = Element('testcase', {'name': self.name,
                                        'classname': self.classname,
                                        'time': self.time})
+
+        if self.skipped_case.has_skipped_case():
+            element.append(self.skipped_case.convert_to_xml())
+
+        if self.failure_case.has_failure_case():
+            element.append(self.failure_case.convert_to_xml())
+
+        if self.error_case.has_error_case():
+            element.append(self.error_case.convert_to_xml())
+
         return element
 
 
+class XUnitSkippedCase(object):
+    def __init__(self, case):
+        self.case = case
+
+    def has_skipped_case(self):
+        return self.case.skipped or self.case.incomplete
+
+    def convert_to_xml(self):
+        element = Element('skipped')
+        element.text = "SKIPPED REASON PLACEHOLDER"
+        return element
+
+
+class XUnitFailureCase(object):
+    def __init__(self, case):
+        self.case = case
+
+    def has_failure_case(self):
+        return not self.case.successful
+
+    def convert_to_xml(self):
+        element = Element('failure')
+        element.text = "FAILURE REASON PLACEHOLDER"
+        return element
+
+
+class XUnitErrorCase(object):
+    def __init__(self, case):
+        self.case = case
+
+    def has_error_case(self):
+        return self.case.errors
+
+    def convert_to_xml(self):
+        element = Element('error')
+        element.text = "ERROR REASON PLACEHOLDER"
+        return element

--- a/specter/reporting/xunit.py
+++ b/specter/reporting/xunit.py
@@ -51,7 +51,7 @@ class XUnitTestSuite(object):
 
     @property
     def time(self):
-        return "N/A"
+        return str(self.suite.elapsed_time)
 
     @property
     def errors(self):
@@ -101,7 +101,7 @@ class XUnitTestCase(object):
 
     @property
     def time(self):
-        return "N/A"
+        return str(self.case.elapsed_time)
 
     def convert_to_xml(self):
         element = Element('testcase', {'name': self.name,

--- a/specter/reporting/xunit.py
+++ b/specter/reporting/xunit.py
@@ -148,10 +148,12 @@ class XUnitFailureCase(object):
     def has_failure_case(self):
         return not self.case.successful and not self.case.errors
 
-    def failure_message(self, expect):
+    @staticmethod
+    def failure_message(expect):
         return f'Failed: {expect.evaluation}'
 
-    def failure_body(self, expect):
+    @staticmethod
+    def failure_body(expect):
         return f"""
         <![CDATA[
         Target: {expect.target} : {expect.target_name}
@@ -179,7 +181,19 @@ class XUnitErrorCase(object):
     def has_error_case(self):
         return self.case.errors
 
+    @staticmethod
+    def error_message(errors):
+        all_errors = ''
+        for error in errors:
+            all_errors += '\n'.join(str(line) for line in error)
+
+        return f'''
+        <![CDATA[Traceback occurred during execution:
+        {all_errors}
+        ]]>
+        '''
+
     def convert_to_xml(self):
         element = Element('error')
-        element.text = "ERROR REASON PLACEHOLDER"
+        element.text = self.error_message(self.case.errors)
         return element

--- a/specter/reporting/xunit.py
+++ b/specter/reporting/xunit.py
@@ -112,7 +112,7 @@ class XUnitTestCase(object):
             element.append(self.skipped_case.convert_to_xml())
 
         if self.failure_case.has_failure_case:
-            element.append(self.failure_case.convert_to_xml())
+            element.extend(self.failure_case.convert_to_xml())
 
         if self.error_case.has_error_case:
             element.append(self.error_case.convert_to_xml())
@@ -148,10 +148,27 @@ class XUnitFailureCase(object):
     def has_failure_case(self):
         return not self.case.successful and not self.case.errors
 
+    def failure_message(self, expect):
+        return f'Failed: {expect.evaluation}'
+
+    def failure_body(self, expect):
+        return f"""
+        <![CDATA[
+        Target: {expect.target} : {expect.target_name}
+        Expected: {expect.expected} : {expect.expected_name}
+        ]]>
+        """
+
     def convert_to_xml(self):
-        element = Element('failure')
-        element.text = "FAILURE REASON PLACEHOLDER"
-        return element
+        elements = []
+
+        for expect in self.case.expects:
+            if not expect.success:
+                element = Element('failure', {'message': self.failure_message(expect)})
+                element.text = self.failure_body(expect)
+                elements.append(element)
+
+        return elements
 
 
 class XUnitErrorCase(object):

--- a/specter/reporting/xunit.py
+++ b/specter/reporting/xunit.py
@@ -45,8 +45,37 @@ class XUnitTestSuite(object):
     def __init__(self, suite):
         self.suite = suite
 
+    @property
+    def name(self):
+        return self.suite.name
+
+    @property
+    def time(self):
+        return "N/A"
+
+    @property
+    def errors(self):
+        return str(len([case for case in self.suite.cases if case.errors]))
+
+    @property
+    def failures(self):
+        return str(len([case for case in self.suite.cases if not case.successful]))
+
+    @property
+    def skipped(self):
+        return str(len([case for case in self.suite.cases if case.skipped or case.incomplete]))
+
+    @property
+    def tests(self):
+        return str(len(self.suite.cases))
+
     def convert_to_xml(self):
-        element = Element('testsuite', {'name': self.suite.name})
+        element = Element('testsuite', {'name': self.name,
+                                        'time': self.time,
+                                        'errors': self.errors,
+                                        'failures': self.failures,
+                                        'skipped': self.skipped,
+                                        'tests': self.tests})
 
         for case in self.suite.cases:
             test_case = XUnitTestCase(case)
@@ -59,8 +88,22 @@ class XUnitTestCase(object):
     def __init__(self, case):
         self.case = case
 
+    @property
+    def name(self):
+        return self.case.raw_name
+
+    @property
+    def classname(self):
+        return "N/A"
+
+    @property
+    def time(self):
+        return "N/A"
+
     def convert_to_xml(self):
-        element = Element('testcase', {'name': self.case.raw_name})
+        element = Element('testcase', {'name': self.name,
+                                       'classname': self.classname,
+                                       'time': self.time})
         return element
 
 

--- a/specter/reporting/xunit.py
+++ b/specter/reporting/xunit.py
@@ -108,13 +108,13 @@ class XUnitTestCase(object):
                                        'classname': self.classname,
                                        'time': self.time})
 
-        if self.skipped_case.has_skipped_case():
+        if self.skipped_case.has_skipped_case:
             element.append(self.skipped_case.convert_to_xml())
 
-        if self.failure_case.has_failure_case():
+        if self.failure_case.has_failure_case:
             element.append(self.failure_case.convert_to_xml())
 
-        if self.error_case.has_error_case():
+        if self.error_case.has_error_case:
             element.append(self.error_case.convert_to_xml())
 
         return element
@@ -124,12 +124,19 @@ class XUnitSkippedCase(object):
     def __init__(self, case):
         self.case = case
 
+    @property
     def has_skipped_case(self):
         return self.case.skipped or self.case.incomplete
 
+    @property
+    def skip_msg(self):
+        if self.case.incomplete:
+            return "Test Case Marked as Incomplete."
+        return self.case.skip_reason
+
     def convert_to_xml(self):
         element = Element('skipped')
-        element.text = "SKIPPED REASON PLACEHOLDER"
+        element.text = self.skip_msg
         return element
 
 
@@ -137,8 +144,9 @@ class XUnitFailureCase(object):
     def __init__(self, case):
         self.case = case
 
+    @property
     def has_failure_case(self):
-        return not self.case.successful
+        return not self.case.successful and not self.case.errors
 
     def convert_to_xml(self):
         element = Element('failure')
@@ -150,6 +158,7 @@ class XUnitErrorCase(object):
     def __init__(self, case):
         self.case = case
 
+    @property
     def has_error_case(self):
         return self.case.errors
 

--- a/specter/reporting/xunit.py
+++ b/specter/reporting/xunit.py
@@ -1,3 +1,4 @@
+from xml.etree.ElementTree import Element, tostring as element_to_str
 from specter import logger
 
 log = logger.get(__name__)
@@ -7,8 +8,51 @@ class XUnitRenderer(object):
     def __init__(self, manager, reporting_options=None):
         self.manager = manager
         self.reporting_options = reporting_options or {}
+        self.filename = self.reporting_options.get('xunit_results')
+        self.report = None
+
+    def convert_to_xml(self):
+        element = Element('testsuites')
+
+        for spec in self.report:
+            test_suite = XUnitTestSuite(spec)
+            element.append(test_suite.convert_to_xml())
+
+        return element
 
     def render(self, report):
-        print("************************")
-        print("XUnitRenderer!")
-        print("************************")
+        if not self.filename:
+            return
+
+        self.report = report
+
+        body = element_to_str(self.convert_to_xml(), encoding='utf8')
+
+        handle = open(self.filename, 'w')
+        handle.write(body.decode('utf8'))
+        handle.close()
+
+
+class XUnitTestSuite(object):
+    def __init__(self, suite):
+        self.suite = suite
+
+    def convert_to_xml(self):
+        element = Element('testsuite', {'name': self.suite.name})
+
+        for case in self.suite.cases:
+            test_case = XUnitTestCase(case)
+            element.append(test_case.convert_to_xml())
+
+        return element
+
+
+class XUnitTestCase(object):
+    def __init__(self, case):
+        self.case = case
+
+    def convert_to_xml(self):
+        element = Element('testcase', {'name': self.case.raw_name})
+        return element
+
+

--- a/specter/reporting/xunit.py
+++ b/specter/reporting/xunit.py
@@ -1,0 +1,14 @@
+from specter import logger
+
+log = logger.get(__name__)
+
+
+class XUnitRenderer(object):
+    def __init__(self, manager, reporting_options=None):
+        self.manager = manager
+        self.reporting_options = reporting_options or {}
+
+    def render(self, report):
+        print("************************")
+        print("XUnitRenderer!")
+        print("************************")

--- a/specter/reporting/xunit.py
+++ b/specter/reporting/xunit.py
@@ -15,8 +15,16 @@ class XUnitRenderer(object):
         element = Element('testsuites')
 
         for spec in self.report:
-            test_suite = XUnitTestSuite(spec)
-            element.append(test_suite.convert_to_xml())
+            element = self.suite_tree(spec, element)
+
+        return element
+
+    def suite_tree(self, spec, element):
+        test_suite = XUnitTestSuite(spec)
+        element.append(test_suite.convert_to_xml())
+
+        for child_spec in spec.specs:
+            element = self.suite_tree(child_spec, element)
 
         return element
 

--- a/specter/reporting/xunit.py
+++ b/specter/reporting/xunit.py
@@ -67,12 +67,17 @@ class XUnitTestSuite(object):
         return str(len(self.suite.cases))
 
     def convert_to_xml(self):
-        element = Element('testsuite', {'name': self.name,
-                                        'time': self.time,
-                                        'errors': self.errors,
-                                        'failures': self.failures,
-                                        'skipped': self.skipped,
-                                        'tests': self.tests})
+        element = Element(
+            'testsuite',
+            attrib={
+                'name': self.name,
+                'time': self.time,
+                'errors': self.errors,
+                'failures': self.failures,
+                'skipped': self.skipped,
+                'tests': self.tests,
+            },
+        )
 
         for case in self.suite.cases:
             test_case = XUnitTestCase(case)
@@ -101,9 +106,14 @@ class XUnitTestCase(object):
         return str(self.case.elapsed_time)
 
     def convert_to_xml(self):
-        element = Element('testcase', {'name': self.name,
-                                       'classname': self.classname,
-                                       'time': self.time})
+        element = Element(
+            'testcase',
+            attrib={
+                'name': self.name,
+                'classname': self.classname,
+                'time': self.time,
+            },
+        )
 
         if self.skipped_case.has_skipped_case:
             element.append(self.skipped_case.convert_to_xml())

--- a/specter/reporting/xunit.py
+++ b/specter/reporting/xunit.py
@@ -97,7 +97,7 @@ class XUnitTestCase(object):
 
     @property
     def classname(self):
-        return "N/A"
+        return self.case.class_name
 
     @property
     def time(self):

--- a/specter/reporting/xunit.py
+++ b/specter/reporting/xunit.py
@@ -29,9 +29,6 @@ class XUnitRenderer(object):
         return element
 
     def render(self, report):
-        if not self.filename:
-            return
-
         self.report = report
 
         body = element_to_str(self.convert_to_xml(), encoding='utf8')

--- a/specter/runner.py
+++ b/specter/runner.py
@@ -10,6 +10,7 @@ from specter.exceptions import FailedRequireException
 from specter.spec import get_case_data, Spec, spec_filter, find_children
 from specter.reporting.core import ReportManager
 from specter.reporting.pretty import PrettyRenderer
+from specter.reporting.xunit import XUnitRenderer
 
 logger.setup()
 log = logger.get(__name__)
@@ -20,6 +21,7 @@ class SpecterRunner(object):
         self.semaphore = asyncio.Semaphore(concurrency)
         self.reporting = ReportManager(reporting_options)
         self.renderer = PrettyRenderer(self.reporting, reporting_options)
+        self.xunit_renderer = XUnitRenderer(self.reporting, reporting_options)
 
     def run(self, search_paths, module_name=None, metadata=None, test_names=None):
         loop = asyncio.get_event_loop()
@@ -62,6 +64,7 @@ class SpecterRunner(object):
 
             report = self.reporting.build_report()
             self.renderer.render(report)
+            self.xunit_renderer.render(report)
 
         return self.reporting.success
 

--- a/specter/runner.py
+++ b/specter/runner.py
@@ -64,7 +64,9 @@ class SpecterRunner(object):
 
             report = self.reporting.build_report()
             self.renderer.render(report)
-            self.xunit_renderer.render(report)
+
+            if self.xunit_renderer.filename:
+                self.xunit_renderer.render(report)
 
         return self.reporting.success
 

--- a/specter/utils.py
+++ b/specter/utils.py
@@ -105,7 +105,7 @@ def snakecase_to_spaces(value):
 
 
 def pretty_class_name(value):
-    return value.replace("<class '", '').replace("'>", '')
+    return f'{type(value).__module__}.{type(value).__qualname__}'
 
 
 def extract_metadata(case_func):

--- a/specter/utils.py
+++ b/specter/utils.py
@@ -104,6 +104,10 @@ def snakecase_to_spaces(value):
     return value.replace('_', ' ')
 
 
+def pretty_class_name(value):
+    return value.replace("<class '", '').replace("'>", '')
+
+
 def extract_metadata(case_func):
     # Handle metadata decorator
     metadata = {}

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -10,5 +10,4 @@ def runner():
 
 def test_can_run(runner):
     runner.run(['./tests/example_data'])
-    report = runner.reporting.build_report()
     pass


### PR DESCRIPTION
* Added XUnit Renderer
* Added elapsed time and class name attributes to Spec Format Data class
* Added elapsed time attribute to Case Format Data class
* Added helper util to print out a pretty class name
* Fixed existing flake8 issues