### PR TITLE
Spec dependency awareness for selective setup execution

### DIFF
--- a/specter/spec.py
+++ b/specter/spec.py
@@ -109,6 +109,17 @@ class Spec(object):
     def is_fixture(cls):
         return vars(cls).get('__FIXTURE__') is True
 
+    @property
+    def has_dependencies(self):
+        if self.__test_cases__:
+            return True
+
+        for child in self.children:
+            if child.has_dependencies:
+                return True
+
+        return False
+
     @utils.tag_as_inherited
     async def before_all(self):
         pass


### PR DESCRIPTION
* Added `has_dependencies` property to `Spec` to walk down stack and
check for the existence of test cases on all specs in the stack.
* Update runner to filter cases on top-level or parentless specs and
down the stack to filter cases to run on all specs.
* Only execute spec `before_all` method if it has dependencies i.e. test
cases to run or children with test cases to run.